### PR TITLE
Change the name of host related variables in deploy task

### DIFF
--- a/.deploy_pipeline/task.yaml
+++ b/.deploy_pipeline/task.yaml
@@ -138,11 +138,11 @@ spec:
       description: The name of the application passed as environment variable
     - name: virtualserverinstance
       description: The IP Address of the Virtual Server Instance
-    - name: host-ssh-keys
+    - name: hostsshkeys
       description: The private SSH Key required to login to the Virtual Server Instance
-    - name: host-user-name
+    - name: hostusername
       description: The username required to login to the Virtual Server Instance
-    - name: host-password
+    - name: hostpassword
       description: The password required to login to the Virtual Server Instance
     - name: cos-region
       description: The Region where Cloud Object Storage Instance is created


### PR DESCRIPTION
### Description
The name of the variable were mistakenly copied as below (caused due to a previous merge):
- host-ssh-keys
- host-user-name
- host-password

Reverting them to the correct names.

---
### Testing Done

- Failed Run
![image](https://user-images.githubusercontent.com/80688956/112240844-1d8d7380-8c6f-11eb-9a94-70e5557463f2.png)

- Successful Run
![image](https://user-images.githubusercontent.com/80688956/112240929-4877c780-8c6f-11eb-8ccf-67b9573b7193.png)
