### PR TITLE
Tekton-catalog repo should be legal true

### DIFF
--- a/.bluemix/toolchain.yml
+++ b/.bluemix/toolchain.yml
@@ -78,6 +78,7 @@ services:
       type: 'clone'
       has_issues: false
       enable_traceability: false
+      legal: true
       kind: ['pipeline']
   inventory-repo:
     service_id: >


### PR DESCRIPTION
### Description
 Toolchain UI should not ask authorisation for the Tekton-catalog repo 
---

### Testing Done
Tested via creating a toolchain in GHE
---

### Related Issues
